### PR TITLE
Make status description in code execution more clear

### DIFF
--- a/frontend/components/CollabPage/CodeEditor.tsx
+++ b/frontend/components/CollabPage/CodeEditor.tsx
@@ -26,6 +26,7 @@ const CodeEditor = ({ language, editorContent, roomId, question }: Props) => {
         defaultRunCodeResults
     );
     const [isRunningCode, setIsRunningCode] = useState<boolean>(false);
+    const [editorContentState, setEditorContentState] = useState<string>(editorContent);
 
     // options for monaco editor
     const options: editor.IStandaloneEditorConstructionOptions = {
@@ -116,11 +117,6 @@ const CodeEditor = ({ language, editorContent, roomId, question }: Props) => {
                 ) ?? null;
         });
 
-        // reset text in model on next question
-        socket?.on("proceedWithNextQuestion", () => {
-            editorRef.current?.getModel()?.setValue("");
-        });
-
         socket?.on("runCode", () => {
             setIsRunningCode(true);
         });
@@ -134,6 +130,10 @@ const CodeEditor = ({ language, editorContent, roomId, question }: Props) => {
             socket.disconnect();
         };
     }, [roomId]);
+
+    useEffect(() => {
+        editorRef.current?.getModel()?.setValue(editorContent);
+    }, [editorContentState]);
 
     // handle mounting of editor
     const handleEditorDidMount: OnMount = (editor, monaco) => {

--- a/frontend/components/CollabPage/CollabPage.tsx
+++ b/frontend/components/CollabPage/CollabPage.tsx
@@ -259,9 +259,12 @@ const CollabPage = () => {
                             language={language}
                             roomId={roomId}
                             editorContent={
+                                // questions[questionNumber]?.templates?.find(
+                                //     (template) => template.language === language
+                                // )?.starterCode ?? "test"
                                 questions[questionNumber]?.templates?.find(
                                     (template) => template.language === language
-                                )?.starterCode ?? ""
+                                )?.starterCode || "test"   
                             }
                             question={questions[questionNumber]}
                         />

--- a/frontend/components/CollabPage/RunCode/RunCode.tsx
+++ b/frontend/components/CollabPage/RunCode/RunCode.tsx
@@ -27,7 +27,9 @@ const statusDescriptions: StatusDescriptions = {
   };
   
   const getStatusMessage = (statusId: number) => {
-    return statusDescriptions[statusId] || "Code executed successfully";
+    const description = statusDescriptions[statusId];
+    if (description) return description;
+    return statusId === 0 ? "-" : "Code executed successfully";
   };
 
 function RunCode({ runResults }: RunCodeProps) {


### PR DESCRIPTION
Doesn't show code executed successfully even before execution