### PR TITLE
Add id to email for encryption and fix duplicate email issue

### DIFF
--- a/backend/email-service/src/routes/email.ts
+++ b/backend/email-service/src/routes/email.ts
@@ -17,9 +17,8 @@ const transporter = nodemailer.createTransport({
 
 // https://nodemailer.com/about/
 router.post("/", async (req: Request, res: Response) => {
-    const { inviteeEmail } = req.body;
-    const inviteLink =
-        process.env.FRONTEND_URL + "/admin-signup?email=" + inviteeEmail;
+    const { inviteeEmail, inviteId } = req.body;
+    const inviteLink = `${process.env.FRONTEND_URL}/admin-signup?email=${inviteeEmail}&id=${inviteId}`;
     console.log("Generated invite:", inviteLink);
     const info = await transporter.sendMail({
         from: '"PeerPrep" <peerprep@ryanchuahj.com>',

--- a/backend/user-service/package-lock.json
+++ b/backend/user-service/package-lock.json
@@ -10,7 +10,6 @@
             "license": "ISC",
             "dependencies": {
                 "@prisma/client": "^5.4.2",
-                "axios": "^1.6.0",
                 "dotenv": "^16.3.1",
                 "jsonwebtoken": "^9.0.2",
                 "nodemon": "^3.0.1"
@@ -295,21 +294,6 @@
             "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
             "dev": true
         },
-        "node_modules/asynckit": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-        },
-        "node_modules/axios": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.0.tgz",
-            "integrity": "sha512-EZ1DYihju9pwVB+jg67ogm+Tmqc6JmhamRN6I4Zt8DfZu5lbcQGw3ozH9lFejSJgs/ibaef3A9PMXPLeefFGJg==",
-            "dependencies": {
-                "follow-redirects": "^1.15.0",
-                "form-data": "^4.0.0",
-                "proxy-from-env": "^1.1.0"
-            }
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -421,17 +405,6 @@
                 "fsevents": "~2.3.2"
             }
         },
-        "node_modules/combined-stream": {
-            "version": "1.0.8",
-            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-            "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-            "dependencies": {
-                "delayed-stream": "~1.0.0"
-            },
-            "engines": {
-                "node": ">= 0.8"
-            }
-        },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -500,14 +473,6 @@
             },
             "engines": {
                 "node": ">= 0.4"
-            }
-        },
-        "node_modules/delayed-stream": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/depd": {
@@ -656,38 +621,6 @@
             },
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/follow-redirects": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.3.tgz",
-            "integrity": "sha512-1VzOtuEM8pC9SFU1E+8KfTjZyMztRsgEfwQl44z8A25uy13jSzTj6dyK2Df52iV0vgHCfBwLhDWevLn95w5v6Q==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/form-data": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-            "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-            "dependencies": {
-                "asynckit": "^0.4.0",
-                "combined-stream": "^1.0.8",
-                "mime-types": "^2.1.12"
-            },
-            "engines": {
-                "node": ">= 6"
             }
         },
         "node_modules/forwarded": {
@@ -1047,6 +980,7 @@
             "version": "1.52.0",
             "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
             "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+            "dev": true,
             "engines": {
                 "node": ">= 0.6"
             }
@@ -1055,6 +989,7 @@
             "version": "2.1.35",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
             "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+            "dev": true,
             "dependencies": {
                 "mime-db": "1.52.0"
             },
@@ -1225,11 +1160,6 @@
             "engines": {
                 "node": ">= 0.10"
             }
-        },
-        "node_modules/proxy-from-env": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-            "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
         },
         "node_modules/pstree.remy": {
             "version": "1.1.8",

--- a/backend/user-service/package.json
+++ b/backend/user-service/package.json
@@ -23,7 +23,6 @@
     },
     "dependencies": {
         "@prisma/client": "^5.4.2",
-        "axios": "^1.6.0",
         "dotenv": "^16.3.1",
         "jsonwebtoken": "^9.0.2",
         "nodemon": "^3.0.1"

--- a/backend/user-service/prisma/schema.prisma
+++ b/backend/user-service/prisma/schema.prisma
@@ -24,7 +24,7 @@ model User {
 }
 
 model Invitation {
-  id        BigInt   @id(map: "invitation_pkey") @default(autoincrement())
+  id        String   @id(map: "invitation_pkey") @default(cuid())
   email     String   @unique(map: "invitaion_email_key")
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamptz(6)
   invitedBy User     @relation(fields: [userId], references: [id])

--- a/backend/user-service/src/routes/invite.ts
+++ b/backend/user-service/src/routes/invite.ts
@@ -96,7 +96,6 @@ router.post("/", async (req: Request, res: Response) => {
     }
 
     // Send request to email-service
-    console.log(process.env.EMAIL_SERVICE_URL);
     await fetch(process.env.EMAIL_SERVICE_URL as string, {
         method: "POST",
         mode: "cors",

--- a/backend/user-service/src/routes/invite.ts
+++ b/backend/user-service/src/routes/invite.ts
@@ -1,6 +1,5 @@
 import express, { Request, Response } from "express";
 import { PrismaClient } from "@prisma/client";
-import axios from "axios";
 
 const prisma = new PrismaClient({
     log: ["query", "info", "warn", "error"],

--- a/backend/user-service/src/routes/invite.ts
+++ b/backend/user-service/src/routes/invite.ts
@@ -3,7 +3,7 @@ import { PrismaClient } from "@prisma/client";
 import axios from "axios";
 
 const prisma = new PrismaClient({
-    log: ['query', 'info', 'warn', 'error']
+    log: ["query", "info", "warn", "error"],
 });
 const router = express.Router();
 const ADMIN_LIMIT = 10; // A limit of 10 admins
@@ -97,17 +97,29 @@ router.post("/", async (req: Request, res: Response) => {
     }
 
     // Send request to email-service
-    const response = await axios.post(process.env.EMAIL_SERVICE_URL as string, {
-        inviteeEmail: inviteeEmail,
-        inviteId: newInvitation.id,
+    console.log(process.env.EMAIL_SERVICE_URL);
+    await fetch(process.env.EMAIL_SERVICE_URL as string, {
+        method: "POST",
+        mode: "cors",
+        credentials: "same-origin",
+        headers: {
+            "Content-Type": "application/json",
+        },
+        redirect: "follow",
+        referrerPolicy: "no-referrer",
+        body: JSON.stringify({
+            inviteeEmail: inviteeEmail,
+            inviteId: newInvitation.id.valueOf(),
+        }),
+    }).then((response) => {
+        if (response.status !== 200) {
+            console.log("Received response:", response);
+            res.status(400).json({
+                message: `Failed to send new Email`,
+            });
+            return;
+        }
     });
-    if (!response || response.status !== 200) {
-        console.log("Received response:", response);
-        res.status(400).json({
-            message: `Failed to send new Email`,
-        });
-        return;
-    }
 
     res.status(201).json(`Invite: ${newInvitation.email} has been created`);
 });

--- a/backend/user-service/src/routes/invite.ts
+++ b/backend/user-service/src/routes/invite.ts
@@ -85,6 +85,7 @@ router.post("/", async (req: Request, res: Response) => {
             createdAt: new Date(),
         },
         select: {
+            id: true,
             email: true,
         },
     });
@@ -98,6 +99,7 @@ router.post("/", async (req: Request, res: Response) => {
     // Send request to email-service
     const response = await axios.post(process.env.EMAIL_SERVICE_URL as string, {
         inviteeEmail: inviteeEmail,
+        inviteId: newInvitation.id,
     });
     if (!response || response.status !== 200) {
         console.log("Received response:", response);

--- a/backend/user-service/src/routes/users.ts
+++ b/backend/user-service/src/routes/users.ts
@@ -166,10 +166,10 @@ router.delete("/", async (req: Request, res: Response) => {
  *  @returns status 410 Gone if link has already expired.
  */
 router.post("/verify-invitation", async (req: Request, res: Response) => {
-    const { email } = req.body;
+    const { id } = req.body;
     const invitedUser = await prisma.invitation.findUnique({
         where: {
-            email: email,
+            id: id,
         },
         select: {
             email: true,
@@ -179,7 +179,7 @@ router.post("/verify-invitation", async (req: Request, res: Response) => {
 
     if (!invitedUser) {
         res.status(404).json({
-            message: `Email: ${email} not found in invitations`,
+            message: `Id: ${id} not found in invitations`,
         });
         return;
     }
@@ -196,7 +196,7 @@ router.post("/verify-invitation", async (req: Request, res: Response) => {
         return;
     }
 
-    res.status(200).json(`${email} has an invitation`);
+    res.status(200).json(`${id} has an invitation`);
 });
 
 export default router;

--- a/frontend/components/ProfilePage/ProfilePage.tsx
+++ b/frontend/components/ProfilePage/ProfilePage.tsx
@@ -107,7 +107,10 @@ const ProfilePage = () => {
             .then((res) => {
                 console.log(res);
                 if (res.status === 201) {
-                    setInvites([...invites, inviteeEmail]);
+                    if (!invites.includes(inviteeEmail)) {
+                        // Add email if not already in list of invites
+                        setInvites([...invites, inviteeEmail]);
+                    }
                     setInviteeEmail("");
                 } else {
                     messageHandler(res.message, "error");

--- a/frontend/pages/admin-signup.tsx
+++ b/frontend/pages/admin-signup.tsx
@@ -20,13 +20,12 @@ const AdminSignupPage: NextPage = () => {
     useEffect(() => {
         /* On load, verify if user can be on this page */
         const verifyUser = async () => {
-            const email = router.query.email;
+            const id = router.query.id;
             await fetchPost("/api/users/verify-invitation", {
-                email: email,
+                id: id,
             }).then((res) => {
-                console.log(res);
                 if (res.status === 200) {
-                    console.log("Setting verified");
+                    console.log(res.data);
                     if (redirectTimer) clearTimeout(redirectTimer);
                     setVerified(true);
                 } else {

--- a/frontend/pages/api/users/verify-invitation.ts
+++ b/frontend/pages/api/users/verify-invitation.ts
@@ -6,14 +6,14 @@ export default async function handler(
     res: NextApiResponse<ResponseData>
 ) {
     if (req.method === "POST") {
-        const { email } = req.body;
-        if (email) {
+        const { id } = req.body;
+        if (id) {
             try {
                 const express_gateway: string =
                     (process.env.GATEWAY_SERVER_URL as string) +
                     "/api/users/verify-invitation";
                 const response = await fetchPost(express_gateway as string, {
-                    email: email,
+                    id: id,
                 });
                 console.log(response);
                 return res.json({ status: 200, data: response });
@@ -31,7 +31,7 @@ export default async function handler(
         } else {
             return res.json({
                 status: 400,
-                message: `Expected email, received ${email}`,
+                message: `Expected id, received ${id}`,
             });
         }
     } else {


### PR DESCRIPTION
Add an inviteId to provide extra encryption for invite links

I updated the database schema to convert invite ids to cuid so we could use them to provide further encryption for invite links. Admin-signup page verifies the id matches that in the database before rendering the admin signup box.

Fix existing issue with email creation. Close #91 

Frontend now checks for existing emails before updating the list