### PR TITLE
Add Continuous Deployment for gateway and services

### DIFF
--- a/.github/workflows/ai.service.deploy.yml
+++ b/.github/workflows/ai.service.deploy.yml
@@ -1,0 +1,62 @@
+name: Ai Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up environment
+      run: |
+        echo "OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" >> .env
+        cat .env # Verify that secrets are set
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push ai-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_ai:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-ai:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-ai:$IMAGE_TAG
+        echo "push image=ai" >> $GITHUB_OUTPUT
+
+    - name: Download ai-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-ai-service --query taskDefinition > ai-task-definition.json
+    
+    - name: Deploy Amazon ECS ai-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: ai-task-definition.json
+        service: ai
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/collaboration.service.deploy.yml
+++ b/.github/workflows/collaboration.service.deploy.yml
@@ -17,6 +17,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up environment
+      run: |
+        echo "NEXT_PUBLIC_PORT_NUMBER=3001" >> .env
+        echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+        cat .env # Verify that secrets are set
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/collaboration.service.deploy.yml
+++ b/.github/workflows/collaboration.service.deploy.yml
@@ -1,0 +1,57 @@
+name: Collaboration Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push collaboration container to ecr
+        docker tag ay2324s1-course-assessment-g58_collaboration:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-collaboration:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-collaboration:$IMAGE_TAG
+        echo "push image=collaboration" >> $GITHUB_OUTPUT
+
+    - name: Download collaboration-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-collaboration-service --query taskDefinition > collaboration-task-definition.json    
+      
+    - name: Deploy Amazon ECS collaboration-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: collaboration-task-definition.json
+        service: collaboration
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/compiler.service.deploy.yml
+++ b/.github/workflows/compiler.service.deploy.yml
@@ -17,6 +17,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up environment
+      run: |
+        echo "NEXT_PUBLIC_PORT_NUMBER=3001" >> .env
+        echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+        cat .env # Verify that secrets are set
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/compiler.service.deploy.yml
+++ b/.github/workflows/compiler.service.deploy.yml
@@ -1,0 +1,57 @@
+name: Compiler Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push compiler-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_compiler:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-compiler:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-compiler:$IMAGE_TAG
+        echo "push image=compiler" >> $GITHUB_OUTPUT
+
+    - name: Download compiler-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-compiler-service --query taskDefinition > compiler-task-definition.json
+
+    - name: Deploy Amazon ECS compiler-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: compiler-task-definition.json
+        service: compiler
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/email.service.deploy.yml
+++ b/.github/workflows/email.service.deploy.yml
@@ -1,0 +1,63 @@
+name: Email Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up environment
+      run: |
+        echo "FRONTEND_URL=${{ secrets.FRONTEND_URL }}" >> .env
+        echo "SMTP_PASSWORD=${{ secrets.SMTP_PASSWORD }}" >> .env
+        cat .env # Verify that secrets are set
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push email-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_email:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-email:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-email:$IMAGE_TAG
+        echo "push image=email" >> $GITHUB_OUTPUT
+     
+    - name: Download email-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-email-service --query taskDefinition > email-task-definition.json
+
+    - name: Deploy Amazon ECS email-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: email-task-definition.json
+        service: email
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/gateway.deploy.yml
+++ b/.github/workflows/gateway.deploy.yml
@@ -1,0 +1,57 @@
+name: Gateway CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push gateway container to ecr
+        docker tag ay2324s1-course-assessment-g58_gateway:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-gateway:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-gateway:$IMAGE_TAG
+        echo "push image=gateway" >> $GITHUB_OUTPUT
+
+    - name: Download gateway-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-api-gateway --query taskDefinition > gateway-task-definition.json
+
+    - name: Deploy Amazon ECS api-gateway task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: gateway-task-definition.json
+        service: api-gateway
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/gateway.deploy.yml
+++ b/.github/workflows/gateway.deploy.yml
@@ -17,6 +17,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up environment
+      run: |
+        echo "NEXT_PUBLIC_PORT_NUMBER=3001" >> .env
+        echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+        cat .env # Verify that secrets are set
+        
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/matching.service.deploy.yml
+++ b/.github/workflows/matching.service.deploy.yml
@@ -17,6 +17,12 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
 
+    - name: Set up environment
+      run: |
+        echo "NEXT_PUBLIC_PORT_NUMBER=3001" >> .env
+        echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+        cat .env # Verify that secrets are set
+
     - name: Configure AWS credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:

--- a/.github/workflows/matching.service.deploy.yml
+++ b/.github/workflows/matching.service.deploy.yml
@@ -1,0 +1,57 @@
+name: Matching Service CI
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push matching-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_matching:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-matching:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-matching:$IMAGE_TAG
+        echo "push image=matching" >> $GITHUB_OUTPUT
+     
+    - name: Download matching-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-matching-service --query taskDefinition > matching-task-definition.json
+
+    - name: Deploy Amazon ECS matching-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: matching-task-definition.json
+        service: matching
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/question.service.deploy.yml
+++ b/.github/workflows/question.service.deploy.yml
@@ -1,0 +1,62 @@
+name: Question Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up environment
+      run: |
+        echo "MONGODB_URL=${{ secrets.MONGODB_URL }}" >> .env
+        cat .env # Verify that secrets are set
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push question-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_questions:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-questions:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-questions:$IMAGE_TAG
+        echo "push image=questions" >> $GITHUB_OUTPUT
+
+    - name: Download question-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-question-service --query taskDefinition > question-task-definition.json
+
+    - name: Deploy Amazon ECS question-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: question-task-definition.json
+        service: questions
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/.github/workflows/user.service.deploy.yml
+++ b/.github/workflows/user.service.deploy.yml
@@ -1,0 +1,63 @@
+name: User Service CD
+
+on:
+  push:
+    branches: [ "main", "staging" ]
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up environment
+      run: |
+        echo "NEXT_PUBLIC_PORT_NUMBER=3001" >> .env
+        echo "DATABASE_URL=${{ secrets.DATABASE_URL }}" >> .env
+        cat .env # Verify that secrets are set
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.AWS_REGION }}
+
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Build, tag, and push image to Amazon ECR
+      id: build-image
+      env:
+        ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+        IMAGE_TAG: latest
+      run: |
+        # Build a docker container and
+        # push it to ECR so that it can
+        # be deployed to ECS.
+        docker-compose -f docker-compose-deployment.yml build
+
+        # Push user-service container to ecr
+        docker tag ay2324s1-course-assessment-g58_users:$IMAGE_TAG $ECR_REGISTRY/ay2324s1-course-assessment-g58-users:$IMAGE_TAG
+        docker push $ECR_REGISTRY/ay2324s1-course-assessment-g58-users:$IMAGE_TAG
+        echo "push image=users" >> $GITHUB_OUTPUT
+
+    - name: Download user-service task definition
+      run: |
+        aws ecs describe-task-definition --task-definition peerprep-user-service --query taskDefinition > user-task-definition.json
+
+    - name: Deploy Amazon ECS user-service task
+      uses: aws-actions/amazon-ecs-deploy-task-definition@df9643053eda01f169e64a0e60233aacca83799a
+      with:
+        task-definition: user-task-definition.json
+        service: users
+        cluster: peerprep_t
+        wait-for-service-stability: true

--- a/backend/email-service/src/index.ts
+++ b/backend/email-service/src/index.ts
@@ -16,5 +16,5 @@ app.use(express.json());
 app.use("/email", emailRouter);
 
 app.get("/", (req: Request, res: Response) => {
-    console.log("Hello from email-service!");
+    res.send("Hello from email-service!");
 });

--- a/docker-compose-deployment.yml
+++ b/docker-compose-deployment.yml
@@ -23,10 +23,7 @@ services:
             dockerfile: ./gateway/Dockerfile
         ports:
             - "8080:8080"
-        environment:
-            - USER_SERVICE_URL=http://users:3001
-            - QUESTION_SERVICE_URL=http://questions:3002
-            - RABBITMQ_URL=amqp://user:password@rabbitmq:5672
+
     users:
         depends_on:
             - email

--- a/docker-compose-deployment.yml
+++ b/docker-compose-deployment.yml
@@ -1,0 +1,170 @@
+version: '3.8'
+
+x-logging:
+  &default-logging
+  logging:
+    driver: json-file
+    options:
+      max-size: 100m
+
+services:
+    gateway:
+        depends_on:
+            - users
+            - questions
+            - matching
+            - collaboration
+            - compiler
+            - ai
+            - email
+        container_name: gateway
+        build:
+            context: .
+            dockerfile: ./gateway/Dockerfile
+        ports:
+            - "8080:8080"
+        environment:
+            - USER_SERVICE_URL=http://users:3001
+            - QUESTION_SERVICE_URL=http://questions:3002
+            - RABBITMQ_URL=amqp://user:password@rabbitmq:5672
+    users:
+        depends_on:
+            - email
+        container_name: user-service
+        build:
+            context: .
+            dockerfile: ./backend/user-service/Dockerfile
+        env_file:
+            - .env
+        ports:
+            - "3001:3001"
+
+    questions:
+        container_name: question-service
+        build:
+            context: .
+            dockerfile: ./mongodb-database/Dockerfile
+        ports:
+            - "3002:3002"
+
+    matching:
+        container_name: matching-service
+        build:
+            context: .
+            dockerfile: ./matching-service/Dockerfile
+        ports:
+            - "3004:3004"
+
+    collaboration:
+        container_name: collaboration-service
+        build:
+            context: .
+            dockerfile: ./collaboration-service/Dockerfile
+        ports:
+            - "3005:3005"
+
+    compiler:
+        depends_on:
+            - server
+            - workers
+            - db
+            - redis
+            - rabbitmq
+        container_name: compiler-service
+        build:
+            context: .
+            dockerfile: ./compiler-service/Dockerfile
+        ports:
+            - "3006:3006"
+    
+    email:
+        container_name: email-service
+        build:
+            context: .
+            dockerfile: ./backend/email-service/Dockerfile
+        ports:
+            - "3007:3007"
+
+    ai:
+        container_name: ai-service
+        depends_on:
+            - rabbitmq
+        build:
+            context: .
+            dockerfile: ./backend/ai-service/Dockerfile
+        ports:
+            - "3008:3008"
+
+    server: # Judge0
+        image: judge0/judge0:1.13.0
+        volumes:
+            - ./backend/judge0/judge0.conf:/judge0.conf:ro
+        ports:
+            - "2358:2358"
+        privileged: true
+        <<: *default-logging
+        restart: always
+
+    workers: # Judge0
+        image: judge0/judge0:1.13.0
+        command: ["./scripts/workers"]
+        volumes:
+            - ./backend/judge0/judge0.conf:/judge0.conf:ro
+        privileged: true
+        <<: *default-logging
+        restart: always
+
+    db: # Judge0
+        image: postgres:13.0
+        environment:
+            - REDIS_HOST=redis
+            - REDIS_PASSWORD=YourPasswordHere1234
+            - POSTGRES_HOST=db
+            - POSTGRES_DB=judge0
+            - POSTGRES_USER=judge0
+            - POSTGRES_PASSWORD=YourPasswordHere1234
+        volumes:
+            - postgres-data:/var/lib/postgresql/data/
+        <<: *default-logging
+        restart: always
+
+    redis: # Judge0
+        image: redis:6.0
+        command: [
+            "bash", "-c",
+            'docker-entrypoint.sh --appendonly yes --requirepass "$$REDIS_PASSWORD"'
+        ]
+        environment:
+            - REDIS_HOST=redis
+            - REDIS_PASSWORD=YourPasswordHere1234
+            - POSTGRES_HOST=db
+            - POSTGRES_DB=judge0
+            - POSTGRES_USER=judge0
+            - POSTGRES_PASSWORD=YourPasswordHere1234
+        volumes:
+            - redis-data:/data
+        <<: *default-logging
+        restart: always
+
+    rabbitmq:
+        image: rabbitmq:management
+        hostname: rabbitmq
+        ports:
+            - "5672:5672"      # AMQP protocol
+            - "15672:15672"    # Management UI
+        expose:
+            - 5672
+            - 15672
+        environment:
+            RABBITMQ_DEFAULT_USER: user
+            RABBITMQ_DEFAULT_PASS: password
+        volumes:
+            - rabbitmq_data:/var/lib/rabbitmq
+            - rabbitmq_log:/var/log/rabbitmq
+
+volumes:
+    postgres-data:
+    redis-data:
+    rabbitmq_data:
+    rabbitmq_log:
+    


### PR DESCRIPTION
These workflow files carry out the following:
1. Docker compose containers
2. Push containers to AWS ECR
3. Download latest task definition for deployment
4. Trigger a deployment of the new containers through their respective AWS ECS services

The deployment of a new instance takes a a few minutes as it spins up a new AWS EC2 instance and waits for it to be ready before replacing the previous instance and bringing the old instance down.

These occur on "push" of main and staging, a PR merge

Compiler service deployment is still a work in progress